### PR TITLE
Update google-analytics.html

### DIFF
--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,8 +1,8 @@
+<!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
-  window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
   window.dataLayer = window.dataLayer || [];
-  function gtag(){window.dataLayer.push(arguments);}
+  function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
   gtag('config', '{{ site.google_analytics }}');


### PR DESCRIPTION
#44 Fix as per GA instructions. 
Removes `do not track` which is no longer recommended as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT