### PR TITLE
Scratch and Blog Post 2

### DIFF
--- a/_posts/2024-09-29-building-kits-dna.md
+++ b/_posts/2024-09-29-building-kits-dna.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Building kits-dna - Post 1
+title: Building my personal website... kits-dna
 date: 2024-09-29
 categories: kits-dna
 ---
@@ -47,7 +47,7 @@ To get started with Jekyll, I’d recommend initialising a git repository locall
 
 In upcoming posts on building `kits-dna` I’ll cover:
 
-- How to use an iPad or tablet to create a website1
+- How to use an iPad or tablet to create a website
 - How to customise the appearance of your site
 - Build Gotcha's on GitHub Pages
 - How to make your site look good on mobile

--- a/_posts/2024-10-11-how-to-use-an-iPad-or-tablet-to-create-a-website.md
+++ b/_posts/2024-10-11-how-to-use-an-iPad-or-tablet-to-create-a-website.md
@@ -1,0 +1,51 @@
+---
+layout: post
+title: How to use an iPad or tablet to create a website
+date: 2024-10-11
+categories: kits-dna
+---
+This is the 2nd post in the **Building kits-dna** series.
+
+Most development that I’ve experienced still happens locally - on a devs laptop - before their work is pushed to a central source code management tool such as GitHub, GitLab etc.
+
+I have an old laptop and a slow Raspberry Pi 4, but I do have a newer iPad Pro, so I investigated if there was a way to develop locally using an IDE (Integrated Development Environment) using my iPad. There are a few hacks in this space such as using the iPad to remote onto the Pi or using Working Copy, but native IDE’s aren’t available on iOS.
+
+## GitHub Codespaces
+
+[**GitHub Codespaces**]([https://github.com/features/](https://github.com/features/codespaces)) solved this problem. In a nutshell it’s a configured and secured IDE that runs **Visual Studio Code** in the browser and is integrated natively with GitHub.
+
+With just a config file in your repo, you can spin up a Codespace for *free* (120 hours per month) with all the dependencies you need pre-installed. You can even install VS Code extensions as you would locally.
+
+And best yet for projects like a website where you want to run locally to see changes in real time, Codespaces has port forwarding that allows you to do just that... awesome!
+
+> :memo: **Note:** You can use GitHub Codespaces locally, this means you can use your existing VS Code or another supported IDE.
+
+### Getting Started with GitHub Codespaces
+
+1. Create a Repository on GitHub
+2. On the **Code** tab, click the green **Code** button
+3. Select the **Codespaces** tab
+4. Click **Create codespaces on main**
+
+GitHub will spin up a new Codespaces Virtual Machine (VM) running on the default image. The environment is known as a development or dev container. Read [“Introduction to dev containers”](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers) on GitHub for information on dev containers and custom images.
+
+### Jekyll
+
+If you have cloned or forked `kits-dna` the dev container configuration is part of the repository. There is a directory in the repository root called `.devcontainer` which contains the configuration file `devcontainer.json`. Most of the file is comments but the code required to build a dev containers image with Jekyll is:
+
+```json
+{
+    "name": "Jekyll",
+    "image": "mcr.microsoft.com/devcontainers/jekyll:2-bookworm"
+}
+```
+
+Spinning up a Codespace with this configuration will give you all the dependencies you need to run Ruby and Jekyll commands to build your website.
+
+> :bulb: **Tip:** I highly recommend reading [“Introduction to dev containers”](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers) and give it a go yourself using a predefined configuration.
+
+## Wrap Up
+
+GitHub Codespaces has meant that so far I haven’t needed to shell out £1k+ on a new laptop and the free monthly allowance will be enough for most hobbyists - you can always pay as you go if you need more minutes/hours.
+
+I’ve focussed on my use case of Jekyll in this post, but there are dev container configurations for all sorts, the default image for example includes Python. It would be cool if I can use Codespaces for my future projects but I might end up giving into the temptation of a new shiny laptop!

--- a/projects.md
+++ b/projects.md
@@ -20,7 +20,9 @@ Building the site got me started with markup code, and design. Learning a progra
 
 ## :cat: Scratch Project
 
-Why not start learning programming like a kid. [**Scratch**](https://scratch.mit.edu/) is an MIT project to help kids get into programming by using a fun graphical approach. Scratch is available online and also comes installed on `Raspberry Pi OS`. My plan is to build a small game or animation.
+Why not start learning programming like a kid. [**Scratch**](https://scratch.mit.edu/) is an MIT project to help kids get into programming by using a fun graphical approach. Scratch is available online and also comes installed on `Raspberry Pi OS`.
+
+Check out my [**Scratch**]({{ '/scratch/' | relative_url }}) projects.
 
 ## :pound: Price Scraper
 

--- a/projects.md
+++ b/projects.md
@@ -12,25 +12,25 @@ For my first *personal* foray into technology, why not start with a personal web
 
 My site is hosted on GitHub Pages and built using **Jekyll**. The theme is **Minima**, with some custom `HTML` and `CSS`. I built the site entirely on my iPad Pro using **GitHub Codespaces**.
 
-I created the homepage image myself by drawing [**bikablo**](https://bikablo.com/en/home-page/) style visuals. I'm terrible at drawing but I'm pleased how well they turned out. The Apple **Freeform** app helped me out by smoothing some lines. Hopefully product people will recognise what the visuals represent. The site logo is AI generated using **DALL.E**.
+I created the homepage image myself by drawing **bikablo** style visuals. I'm terrible at drawing but I'm pleased how well they turned out. The Apple **Freeform** app helped me out by smoothing some lines. Hopefully product people will recognise what the visuals represent. The site logo is AI generated using **DALL.E**.
 
 Check out my [blog]({{ '/blog/' | relative_url }}) for more on building `kits-dna` if you're interested.
 
 Building the site got me started with markup code, and design. Learning a programming language is next up.
 
-## :cat: Scratch Project
+## :cat: Scratch
 
-Why not start learning programming like a kid. [**Scratch**](https://scratch.mit.edu/) is an MIT project to help kids get into programming by using a fun graphical approach. Scratch is available online and also comes installed on `Raspberry Pi OS`.
+Why not start learning programming like a kid. **Scratch** is an MIT project to help kids get into programming by using a fun graphical approach. Scratch is available online and also comes installed on `Raspberry Pi OS`.
 
-Check out my [**Scratch**]({{ '/scratch/' | relative_url }}) projects.
+Check out my [Scratch]({{ '/scratch/' | relative_url }}) projects.
 
-## :pound: Price Scraper
+## :snake: Python
 
 Next step is learning a *text* based programming language. I’m planning to follow [Replit’s 100 days of code](https://replit.com/learn/100-days-of-python) course to learn `python`. On day 100 you build a product price scraper. Not sure what product/s I’ll scrape but this course should be a good introduction to programming.
 
 > "Everybody in this country should learn how to programme a computer, because it teaches you how to think" - Steve Jobs
 
-## :detective: Unknown Product
+## :gift: Product
 
 Increasing the ambition level a bit now. I’ve got an idea for a *product*. Being a product manager, I want to solve a problem, but I might end up in a product anti-pattern and prototype a solution to a problem that *I* have. This project will combine new found technical skills with my product skills.
 

--- a/scratch.html
+++ b/scratch.html
@@ -14,7 +14,7 @@ permalink: /scratch/
 
 <div>
     <h3>Dino Convo</h3>
-    <p>Trevor the T-Rex is hungry, click the green flag to see if he can he find any food...</p>
+    <p>Trevor the T-Rex is hungry, click the green flag to see if he can find any food...</p>
     <iframe src="https://scratch.mit.edu/projects/1078687895/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
 </div>
 

--- a/scratch.html
+++ b/scratch.html
@@ -2,23 +2,30 @@
 layout: default
 permalink: /scratch/
 ---
-    <div class="post-header">
-        <h1 class="post-title">Scratch</h1>
-        <p>I haven't spent loads of time on Scratch but it was quite fun to make up a random story and a quick game.
-            The graphical approach does let you see the code and the order in which the instructions are carried out.
-            The tutorials and shared projects on the Scratch website make it easy to get some ideas and get started.
-        </p>
-        <h2>Projects</h2>
-    </div>
+<div class="post-header">
+    <h1 class="post-title">Scratch</h1>
+    <p>I haven't spent loads of time on <a href="https://scratch.mit.edu/"><b>Scratch</b></a> but it was fun to make up some quick projects.
+        The graphical approach lets you see the code and the order in which the instructions are carried out, which is nice for a beginner.
+        The tutorials and shared projects on the Scratch website make it easy to get some ideas and get started.
+        I also recommend checking out <a href="https://cs50.harvard.edu/scratch/2024/">CS50's Introduction to Programming with Scratch</a>.
+    </p>
+    <h2>Projects</h2>
+</div>
 
-    <div>
-        <h3>Dino Convo</h3>
-        <p>Trevor the T-Rex is hungry, click the green flag to see if he can he find any food...</p>
-        <iframe src="https://scratch.mit.edu/projects/1078687895/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
-    </div>
+<div>
+    <h3>Dino Convo</h3>
+    <p>Trevor the T-Rex is hungry, click the green flag to see if he can he find any food...</p>
+    <iframe src="https://scratch.mit.edu/projects/1078687895/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
+</div>
 
-    <div>
-        <h3>Dino Pong Game</h3>
-        <p>Click the green flag and use your mouse to move the T-Rex to catch the pterosaur.</p>
-        <iframe src="https://scratch.mit.edu/projects/1078536558/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
-    </div>
+<div>
+    <h3>Dino Pong Game</h3>
+    <p>Click the green flag and use your mouse to move the T-Rex to catch the pterosaur.</p>
+    <iframe src="https://scratch.mit.edu/projects/1078536558/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
+</div>
+
+<div>
+    <h3>Dino Maze</h3>
+    <p>Use the arrow keys to move the T-Rex to the Taco... avoid the red lines!</p>
+    <iframe src="https://scratch.mit.edu/projects/1080026047/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
+</div>

--- a/scratch.html
+++ b/scratch.html
@@ -1,0 +1,24 @@
+---
+layout: default
+permalink: /scratch/
+---
+    <div class="post-header">
+        <h1 class="post-title">Scratch</h1>
+        <p>I haven't spent loads of time on Scratch but it was quite fun to make up a random story and a quick game.
+            The graphical approach does let you see the code and the order in which the instructions are carried out.
+            The tutorials and shared projects on the Scratch website make it easy to get some ideas and get started.
+        </p>
+        <h2>Projects</h2>
+    </div>
+
+    <div>
+        <h3>Dino Convo</h3>
+        <p>Trevor the T-Rex is hungry, click the green flag to see if he can he find any food...</p>
+        <iframe src="https://scratch.mit.edu/projects/1078687895/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
+    </div>
+
+    <div>
+        <h3>Dino Pong Game</h3>
+        <p>Click the green flag and use your mouse to move the T-Rex to catch the pterosaur.</p>
+        <iframe src="https://scratch.mit.edu/projects/1078536558/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
+    </div>


### PR DESCRIPTION
Add scratch.html to showcase Scratch projects, this is written in `HTML` due to use of iFrames which have sometimes failed to show on Markdown files. scratch.html is linked from the Projects page under the scratch heading.

Add 2nd blog post in building kits-dna series how-to-use-an-iPad-or-tablet-to-create-a-website.md 