### PR TITLE
Fix jekyll workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.3' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,8 @@
 name: Lighthouse CI
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main
 jobs:
   lhci:
     name: Lighthouse


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for Jekyll and Lighthouse CI. The most important changes include updating the Ruby version and modifying the branches that trigger the Lighthouse CI workflow.

Updates to GitHub Actions workflows:

* [`.github/workflows/jekyll.yml`](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8L39-R39): Updated the Ruby version from `3.1` to `3.3` in the setup step.
* [`.github/workflows/lighthouse.yml`](diffhunk://#diff-46310a6112abe0634d5021fbaff24cd06630a5bad4be4c785cd482b24a0b818fL2-R5): Modified the workflow to ignore pushes to the `main` branch when triggering the Lighthouse CI job.