### PR TITLE
Update Content Security Policy

### DIFF
--- a/_includes/csp.html
+++ b/_includes/csp.html
@@ -1,0 +1,11 @@
+<meta http-equiv="Content-Security-Policy" content="
+default-src 'self';
+script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://github.githubassets.com https://code.jquery.com https://scripts.simpleanalyticscdn.com;
+style-src 'self' 'unsafe-inline' https://github.githubassets.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
+img-src 'self' data: https: https://github.githubassets.com https://*.linkedin.com https://mastodon.social;
+font-src 'self' https://github.githubassets.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
+connect-src 'self' https://mastodon.social https://*.linkedin.com;
+frame-src 'self' https://scratch.mit.edu;
+frame-ancestors 'none';
+form-action 'self';
+upgrade-insecure-requests;">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,13 +2,12 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="Content-Security-Policy-Report-Only" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-src 'self' https://scratch.mit.edu; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests;">
+    {%- if jekyll.environment == 'production' -%}
+    {%- include csp.html -%}
+    {%- endif -%}
     <link rel="icon" type="image/x-icon" href="{{ "/assets/favicons-emoji/favicon.ico" | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/styles.css" | relative_url }}">
-    
     {%- feed_meta -%}
     {%- seo -%}
-
     {%- include custom-head.html -%}
-    
   </head>


### PR DESCRIPTION
This pull request includes changes to enhance the security of the website by updating the Content Security Policy (CSP) and conditionally including it based on the environment. The most important changes include the addition of a new CSP meta tag and modifications to the head template to include the CSP only in the production environment.

Security improvements:

* [`_includes/csp.html`](diffhunk://#diff-60a17f36a77937cdf705b9d960c0aab6b5bd7fdf5d78fb4a3c96bd5082e46a08R1-R11): Added a new meta tag for Content-Security-Policy to specify sources for different types of content, enhancing security by restricting where resources can be loaded from.

Template modifications:

* [`_includes/head.html`](diffhunk://#diff-e241bda4e3c3c6dc1c0b00185b61f6ce19b5eb16e294dd955ca9fa6d01befb0eL5-L13): Modified the head template to conditionally include the new CSP meta tag only if the environment is set to 'production'. This ensures that the CSP is applied only in the production environment.