### PR TITLE
chore: update eleventy to version 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://kitfrance.com",
   "type": "module",
   "dependencies": {
-    "@11ty/eleventy": "^3.0.1-alpha.5",
+    "@11ty/eleventy": "^3.1.0",
     "@11ty/eleventy-fetch": "^5.0.2",
     "@11ty/eleventy-img": "^6.0.1",
     "@11ty/eleventy-navigation": "^1.0.1",


### PR DESCRIPTION
This pull request updates the version of the `@11ty/eleventy` dependency in the `package.json` file to ensure compatibility with the latest features and fixes.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30-R30): Upgraded `@11ty/eleventy` from version `^3.0.1-alpha.5` to `^3.1.0`.