### PR TITLE
Update heading anchors

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -25,7 +25,7 @@ export default async function(eleventyConfig) {
     level: 2,
     permalink: markdownItAnchor.permalink.linkInsideHeader({
       symbol: "#",
-      placement: "before"
+      placement: "after"
     }),
     slugify: (s) => s.trim().toLowerCase().replace(/\s+/g, "-")
   };

--- a/src/_sass/_custom.scss
+++ b/src/_sass/_custom.scss
@@ -156,3 +156,19 @@ justify-content: center;
 .blog-post-list li {
   list-style: none;
 }
+
+// Hide heading anchor by default
+.header-anchor {
+  visibility: hidden;
+}
+
+// Show heading anchor only when the heading is hovered
+h1:hover .header-anchor,
+h2:hover .header-anchor,
+h3:hover .header-anchor,
+h4:hover .header-anchor,
+h5:hover .header-anchor,
+h6:hover .header-anchor {
+  visibility: visible;
+  text-decoration: underline;
+}


### PR DESCRIPTION
This pull request includes changes to improve the user experience for heading anchors in the blog post list. The most important updates involve modifying the placement of heading anchors and adjusting their visibility and styling in the CSS.

### Improvements to heading anchor placement and styling:

* [`eleventy.config.js`](diffhunk://#diff-36a659af5021ea41791e1943be2d81d731ecac74eec458a97fc955a63751325cL28-R28): Changed the `placement` of heading anchors from `"before"` to `"after"` in the permalink configuration to improve readability.

* [`src/_sass/_custom.scss`](diffhunk://#diff-fed02e5e34c2efcdbd776f2cbd2f9303dfffbd3f4ba206e07265672c3c8f045eR159-R174): Added CSS rules to hide heading anchors by default and make them visible with an underline only when the corresponding heading is hovered, enhancing the visual design.