### PR TITLE
chore: update Content Security Policy to allow images from SA

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,4 +1,4 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://scripts.simpleanalyticscdn.com 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self'; connect-src 'self' https://mastodon.social https://*.linkedin.com; frame-src 'self' https://scratch.mit.edu; frame-ancestors 'self' https://scratch.mit.edu; form-action 'self'; object-src 'none'; media-src 'none'; base-uri 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://scripts.simpleanalyticscdn.com 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https://queue.simpleanalyticscdn.com; font-src 'self'; connect-src 'self' https://mastodon.social https://*.linkedin.com; frame-src 'self' https://scratch.mit.edu; frame-ancestors 'self' https://scratch.mit.edu; form-action 'self'; object-src 'none'; media-src 'none'; base-uri 'self'; upgrade-insecure-requests
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) in the `_headers` file to allow images to be loaded from a new domain.

Security policy update:

* [`_headers`](diffhunk://#diff-36d2e18f82e5a1b5840515b6b51620fa614e3863b5767a9f5c7634843216e7d3L2-R2): Modified the CSP by adding `https://queue.simpleanalyticscdn.com` to the `img-src` directive, enabling images to be loaded from this domain.