### PR TITLE
Update CI Node version

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,4 +1,5 @@
 name: ESLint CI
+
 on:
   pull_request:
     branches:
@@ -18,16 +19,16 @@ jobs:
     name: Run ESLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v4
+
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
-          
+          node-version: 24.x
+
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Run ESLint
         run: npm run eslint
         continue-on-error: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,4 +1,5 @@
 name: Lighthouse CI
+
 on:
   pull_request:
     branches:
@@ -14,11 +15,12 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,4 +1,5 @@
 name: Markdownlint CI
+
 on:
   pull_request:
     branches:
@@ -16,7 +17,8 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
     - uses: DavidAnson/markdownlint-cli2-action@v19
       continue-on-error: true
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,29 +1,38 @@
 name: Playwright Tests
+
 on:
   pull_request:
     branches:
       - main
   workflow_dispatch:
+
 permissions:
   contents: read
   actions: write
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - uses: actions/setup-node@v4
       with:
-        node-version: lts/*
+        node-version: 24.x
+
     - name: Install dependencies
       run: npm ci
+
     - name: Build site
       run: npm run build
+
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+
     - name: Run Playwright tests
       run: npx playwright test
+
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,4 +1,5 @@
 name: Vale CI
+
 on:
   pull_request:
     branches:
@@ -17,6 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
       - uses: errata-ai/vale-action@v2.1.1
         continue-on-error: true
         with:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use the latest versions of dependencies and actions, ensuring compatibility and improved performance. The changes primarily involve upgrading the `actions/checkout` and `actions/setup-node` actions, as well as updating Node.js versions across workflows.

### Workflow updates:

#### Common updates across workflows:
* Updated `actions/checkout` from `v3` to `v4` in `.github/workflows/eslint.yml`, `.github/workflows/lighthouse.yml`, `.github/workflows/markdownlint.yml`, `.github/workflows/playwright.yml`, and `.github/workflows/vale.yml`. [[1]](diffhunk://#diff-8deb4e00ff9e68f9e5e25914b8d329a413bfbc90ab5f8c97662324cc68903d2fL21-R27) [[2]](diffhunk://#diff-46310a6112abe0634d5021fbaff24cd06630a5bad4be4c785cd482b24a0b818fL17-R23) [[3]](diffhunk://#diff-1957eea3063ddb68ad0361c7ce7982cf609cbdb01e57c1cc791209d2980e8b7cL19-R21) [[4]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3R2-R35) [[5]](diffhunk://#diff-fb283a864f87402ad79f904d7da2ce21d5b6fb2ac1253c541c5c501027ce66e4R21)
* Updated `actions/setup-node` from `v3` to `v4` and standardized Node.js version to `24.x` across applicable workflows. [[1]](diffhunk://#diff-8deb4e00ff9e68f9e5e25914b8d329a413bfbc90ab5f8c97662324cc68903d2fL21-R27) [[2]](diffhunk://#diff-46310a6112abe0634d5021fbaff24cd06630a5bad4be4c785cd482b24a0b818fL17-R23) [[3]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3R2-R35)