### PR TITLE
fix: remove unnecessary recaptcha integration from contact form

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,4 +1,4 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://scripts.simpleanalyticscdn.com 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https://queue.simpleanalyticscdn.com; font-src 'self'; connect-src 'self' https://mastodon.social https://*.linkedin.com; frame-src 'self' https://scratch.mit.edu https://www.google.com/recaptcha/; frame-ancestors 'self' https://scratch.mit.edu; form-action 'self'; object-src 'none'; media-src 'none'; base-uri 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://scripts.simpleanalyticscdn.com 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https://queue.simpleanalyticscdn.com; font-src 'self'; connect-src 'self' https://mastodon.social https://*.linkedin.com; frame-src 'self' https://scratch.mit.edu; frame-ancestors 'self' https://scratch.mit.edu; form-action 'self'; object-src 'none'; media-src 'none'; base-uri 'self'; upgrade-insecure-requests
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff

--- a/src/_includes/contact-form.njk
+++ b/src/_includes/contact-form.njk
@@ -1,4 +1,4 @@
-<form name="contact" action="success.html" netlify-honeypot="bot-field" data-netlify-recaptcha="true" data-netlify="true">
+<form name="contact" action="success.html" netlify-honeypot="bot-field" data-netlify="true">
   <fieldset>
     <legend>Contact Form</legend>
     <label class="hidden">
@@ -30,7 +30,5 @@
       ></textarea>
     </label>
   </fieldset>
-  <div data-netlify-recaptcha="true"></div>
-  <br />
   <button type="submit">Send a message</button>
 </form>


### PR DESCRIPTION
This pull request includes updates to security policies and modifications to the contact form to remove reCAPTCHA functionality.

### Security policy updates:
* [`_headers`](diffhunk://#diff-36d2e18f82e5a1b5840515b6b51620fa614e3863b5767a9f5c7634843216e7d3L2-R2): Removed `https://www.google.com/recaptcha/` from the `frame-src` directive in the Content Security Policy.

### Contact form modifications:
* [`src/_includes/contact-form.njk`](diffhunk://#diff-435761f01664310a7fae0f27948789ff7535babf7b222133a372bc2452986b70L1-R1): Removed the `data-netlify-recaptcha` attribute from the `<form>` tag and deleted the `<div>` element responsible for rendering the reCAPTCHA widget. [[1]](diffhunk://#diff-435761f01664310a7fae0f27948789ff7535babf7b222133a372bc2452986b70L1-R1) [[2]](diffhunk://#diff-435761f01664310a7fae0f27948789ff7535babf7b222133a372bc2452986b70L33-L34)