### PR TITLE
content(posts): correct verb tense

### DIFF
--- a/src/posts/2025-06-08-learning-to-programme-as-a-product-manager.md
+++ b/src/posts/2025-06-08-learning-to-programme-as-a-product-manager.md
@@ -7,7 +7,7 @@ tags:
   - cs50
 description: I'm currently taking CS50's Introduction to Programming with Python course, here's my half way report.
 ---
-I'm learning [**Python**](https://www.python.org) - a programming language - to build my technical skills. I choose Python because it's often considered one of the easier languages to learn and is a little more readable then `JavaScript` along with being multi-purpose. We also have Python in our tech stack at work.
+I'm learning [**Python**](https://www.python.org) - a programming language - to build my technical skills. I chose Python because it's often considered one of the easier languages to learn and is a little more readable then `JavaScript` along with being multi-purpose. We also have Python in our tech stack at work.
 
 I'm now half way through [CS50's Introduction to Programming with Python](https://cs50.harvard.edu/python/2022/) course and wanted to share my thoughts so far.
 

--- a/src/posts/2025-09-05-learning-to-programme-as-a-product-manager-2.md
+++ b/src/posts/2025-09-05-learning-to-programme-as-a-product-manager-2.md
@@ -8,7 +8,7 @@ tags:
   - ai
 description: I've finished CS50's Introduction to Programming with Python course, here's my full time report.
 ---
-I'm learning [**Python**](https://www.python.org) - a programming language - to build my technical skills. I choose Python because it's often considered one of the easier languages to learn and is a little more readable then `JavaScript` along with being multi-purpose. We also have Python in our tech stack at work.
+I'm learning [**Python**](https://www.python.org) - a programming language - to build my technical skills. I chose Python because it's often considered one of the easier languages to learn and is a little more readable then `JavaScript` along with being multi-purpose. We also have Python in our tech stack at work.
 
 I've now completed [CS50's Introduction to Programming with Python](https://cs50.harvard.edu/python/2022/) course and wanted to share my final thoughts.
 


### PR DESCRIPTION
This pull request makes a minor wording correction in two blog post files to improve grammatical accuracy.

* Changed "I choose Python" to "I chose Python" in the introductory paragraph of both `src/posts/2025-06-08-learning-to-programme-as-a-product-manager.md` [[1]](diffhunk://#diff-edb13be98af8814cc0ff3f2e9253523e7050942b82307d92e16f1a8ae0f97e9dL10-R10) and `src/posts/2025-09-05-learning-to-programme-as-a-product-manager-2.md` [[2]](diffhunk://#diff-5e3578f2740fe17ae54cca77079ed9c81dd6c80394131ef26649f3f172c4e652L11-R11).…tions