### PR TITLE
chore: update build command and package dependencies

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-# command = "npm run deploy"
+command = "npm run build"
 
 [[plugins]]
 package = "netlify-plugin-cache"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "@axe-core/playwright": "^4.10.2",
         "@eslint/js": "^9.37.0",
         "@netlify/plugin-csp-nonce": "^1.5.2",
-        "@playwright/test": "^1.55.1",
-        "@types/node": "^24.6.2",
+        "@playwright/test": "^1.56.0",
+        "@types/node": "^24.7.0",
         "eslint": "^9.37.0",
         "globals": "^16.4.0",
         "markdown-it": "^14.1.0",
@@ -1617,13 +1617,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
-      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.55.1"
+        "playwright": "1.56.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1718,13 +1718,13 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "24.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
-      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
+      "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.13.0"
+        "undici-types": "~7.14.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -5456,13 +5456,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
-      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.55.1"
+        "playwright-core": "1.56.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5475,9 +5475,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
-      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6652,9 +6652,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "build:eleventy": "npx eleventy",
     "build:search": "npx pagefind --site dist",
     "start": "ELEVENTY_ENVIRONMENT=development npm-run-all build:sass --parallel watch:*",
-    "build": "ELEVENTY_ENVIRONMENT=production npm-run-all build:*",
-    "deploy": "ELEVENTY_ENVIRONMENT=production npm-run-all build:*"
+    "build": "ELEVENTY_ENVIRONMENT=production npm-run-all build:*"
   },
   "repository": {
     "type": "git",
@@ -46,8 +45,8 @@
     "@axe-core/playwright": "^4.10.2",
     "@eslint/js": "^9.37.0",
     "@netlify/plugin-csp-nonce": "^1.5.2",
-    "@playwright/test": "^1.55.1",
-    "@types/node": "^24.6.2",
+    "@playwright/test": "^1.56.0",
+    "@types/node": "^24.7.0",
     "eslint": "^9.37.0",
     "globals": "^16.4.0",
     "markdown-it": "^14.1.0",


### PR DESCRIPTION
This pull request updates the build configuration and dependencies to improve the deployment workflow and ensure compatibility with the latest development tools.

Build and deployment workflow updates:

* Changed the Netlify build command in `netlify.toml` from `npm run deploy` to `npm run build`, streamlining the deployment process to use the standard build script.
* Removed the `deploy` script from `package.json`, leaving only the `build` script for production builds, which helps reduce redundancy and potential confusion in deployment commands.

Dependency updates:

* Upgraded `@playwright/test` from version `^1.55.1` to `^1.56.0` and `@types/node` from `^24.6.2` to `^24.7.0` in `package.json` for improved testing capabilities and type support.