### PR TITLE
ci: update dependabot configuration to check for npm updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
+  - package-ecosystem: npm # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: daily
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
This pull request makes a minor update to the `.github/dependabot.yml` configuration file, changing the update schedule for npm dependencies from weekly to daily and making a small formatting adjustment.

- Configuration updates:
  * Changed the npm dependency update schedule from weekly to daily to ensure more frequent updates.
  * Removed unnecessary quotes from the `package-ecosystem` value for npm for cleaner formatting.