### PR TITLE
ci: update dependabot schedules and group configurations for npm, git…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,32 @@
 
 version: 2
 updates:
-  - package-ecosystem: npm # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to improve dependency update management by adjusting update schedules and introducing dependency grouping. These changes help reduce noise from frequent updates and make it easier to manage related dependency updates together.

**Dependabot configuration improvements:**

* Changed the update schedule for `npm` dependencies from daily to weekly and added grouping for minor and patch updates under a single group called `dependencies`.
* Changed the update schedule for `github-actions` from daily to monthly and added grouping for all actions updates under a single group called `github-actions`.
* Changed the update schedule for `docker` dependencies from daily to weekly and added grouping for all Docker updates under a single group called `docker`.…hub-actions, and docker