### PR TITLE
ci: update dependabot configuration with cooldown settings and rename…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
-      dependencies:
+      npm-deps:
         patterns:
           - "*"
         update-types:
@@ -22,8 +24,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
-      github-actions:
+      github-actions-deps:
         patterns:
           - "*"
 
@@ -31,7 +35,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
-      docker:
+      docker-deps:
         patterns:
           - "*"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to improve dependency management by introducing cooldown periods and renaming dependency groups for clarity.

Dependabot configuration improvements:

* Added a `cooldown` setting with `default-days: 7` to all package ecosystems, ensuring that updates are not created more frequently than once every seven days. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R13-R16) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R27-R41)
* Renamed dependency groups for npm, GitHub Actions, and Docker from generic names (`dependencies`, `github-actions`, `docker`) to more descriptive names (`npm-deps`, `github-actions-deps`, `docker-deps`) for better clarity and organization. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R13-R16) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R27-R41)…d groups