### PR TITLE
ci: pin gitleaks and lychee actions dependencies to sha

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm run build:search
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --no-progress --base-url 'http://localhost:8080' 'dist/**/*.html'
           fail: true


### PR DESCRIPTION
This PR:

 Pins gitleaks and lychee actions dependencies to sha.