### PR TITLE
chore: replace hardcoded name with dynamic metadata

### DIFF
--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -8,7 +8,7 @@
         <a href="{{ '/' }}"><img src="/assets/images/hawaii-logo.webp" loading="eager" width="40" height="23" alt="CF" eleventy:ignore></a>
       </li>
       <li>
-        <a class="nav-links" href="{{ '/' }}">Kit France</a>
+        <a class="nav-links" href="{{ '/' }}">{{ metadata.name }}</a>
       </li>
     </ul>
     <ul class="nav-links">

--- a/src/index.njk
+++ b/src/index.njk
@@ -4,7 +4,7 @@ permalink: /
 ---
 <section>
   <div class="homepage">
-    <h1>Kit France</h1>
+    <h1>{{ metadata.name }}</h1>
     <h2>Dad. Husband. Product Manager.</h2>
     <p>Internal PM focused on tools that power product teams.</p>
     <div class="homepage-image">


### PR DESCRIPTION
This PR:
- Updates hardcoded name values in header and homepage to use `metadata.name` data.