### PR TITLE
ci: change dependabot interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     cooldown:
       default-days: 7
     groups:
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
This PR changes the Dependabot package-ecosystem interval from weekly to monthly to avoid PR build up. This should be find for a site like `kits-dna`, and security vulnerabilities will still get flagged.