### PR TITLE
ci: skip playwright and lighthouse on content/image-only PRs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -10,7 +10,35 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should-test: ${{ steps.filter.outputs.test }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            test:
+              - 'src/**'
+              - '!src/posts/**'
+              - '!src/assets/images/**'
+              - 'eleventy.config.js'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'lighthouserc.cjs'
+              - '.github/workflows/lighthouse.yml'
+
   lhci:
+    needs: changes
+    if: needs.changes.outputs.should-test == 'true'
     name: Lighthouse
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,12 +28,15 @@ jobs:
         filters: |
           test:
             - 'src/**'
+            - '!src/posts/**'
+            - '!src/assets/images/**'
             - 'tests/**'
             - 'playwright.config.js'
             - 'eleventy.config.js'
             - 'Dockerfile'
             - 'package.json'
             - 'package-lock.json'
+            - '.github/workflows/playwright.yml'
 
   playwright-tests:
     needs: changes


### PR DESCRIPTION
## Summary

- Add a `changes` gating job to `lighthouse.yml` mirroring the pattern in `playwright.yml`, so Lighthouse no longer runs on PRs that can't affect its scores.
- Tighten the Playwright filter: include the workflow file itself, and exclude `src/posts/**` and `src/assets/images/**` so content and image-only PRs skip the ~30 min run.
- Tailor the Lighthouse filter to its actual inputs (drops `tests/**`, `playwright.config.js`, `Dockerfile`; adds `lighthouserc.cjs` and the workflow file).

Closes #313.

## Test plan

- [ ] Open a doc-only PR (e.g. README change) and confirm both workflows are skipped
- [ ] Open a `src/posts/**`-only PR and confirm both workflows are skipped
- [ ] Open a `src/_sass/**` or `src/_includes/**` PR and confirm both workflows run
- [ ] Edit `.github/workflows/playwright.yml` on a branch and confirm Playwright runs on that PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)