### PR TITLE
test: clean up pre-existing test issues and fix dark-mode AA contrast

### DIFF
--- a/specs/test-plan.md
+++ b/specs/test-plan.md
@@ -38,7 +38,7 @@
 #### TC-002: All primary pages return HTTP 200
 
 **File:** `functional.spec.js`
-**Status:** Not covered
+**Status:** Covered
 
 **Assumption:** Site is running on <http://localhost:8080> with a complete build including the Pagefind search index.
 
@@ -1110,8 +1110,9 @@ The site uses the Pagefind Component UI modal. The trigger lives in the header (
 **Steps:**
 
 1. Navigate to `/`
-2. Find all links matching `a[target="_blank"]`
-3. For each link, assert `rel` contains `noopener` or `noreferrer`
+2. Find all external links (matching `a[href^="http"]` and excluding `kitfrance.com`)
+3. Assert at least one external link is present
+4. For each link, assert `target="_blank"` is set and `rel` contains both `noopener` and `noreferrer`
 
 **Expected:** All external links have security attributes.
 

--- a/src/_sass/_dark-mode.scss
+++ b/src/_sass/_dark-mode.scss
@@ -24,6 +24,10 @@
     :root:not([data-theme]) {
         @include pagefind-dark-vars;
 
+        --pico-primary: #21E299; /* Jade 200 */
+        --pico-primary-underline: rgba(33, 226, 153, 0.5);
+        --pico-primary-hover: #00A66E; /* Jade 400 */
+
         .dark-mode-toggle {
             .light-icon {
                 display: inline-block;  // Show sun in dark mode
@@ -39,6 +43,10 @@
 /* Enabled if forced with data-theme="dark" */
 [data-theme="dark"] {
     @include pagefind-dark-vars;
+
+    --pico-primary: #21E299; /* Jade 200 */
+    --pico-primary-underline: rgba(33, 226, 153, 0.5);
+    --pico-primary-hover: #00A66E; /* Jade 400 */
 
     .dark-mode-toggle {
         .light-icon {

--- a/src/_sass/_dark-mode.scss
+++ b/src/_sass/_dark-mode.scss
@@ -18,15 +18,18 @@
     --pf-modal-backdrop: rgba(0, 0, 0, 0.7);
 }
 
+@mixin dark-theme-vars {
+    --pico-primary: #21E299; /* Jade 200 */
+    --pico-primary-underline: rgba(33, 226, 153, 0.5);
+    --pico-primary-hover: #00A66E; /* Jade 400 */
+}
+
 /* Dark color scheme (Auto) */
 /* Automatically enabled if user has Dark mode enabled */
 @media only screen and (prefers-color-scheme: dark) {
     :root:not([data-theme]) {
         @include pagefind-dark-vars;
-
-        --pico-primary: #21E299; /* Jade 200 */
-        --pico-primary-underline: rgba(33, 226, 153, 0.5);
-        --pico-primary-hover: #00A66E; /* Jade 400 */
+        @include dark-theme-vars;
 
         .dark-mode-toggle {
             .light-icon {
@@ -43,10 +46,7 @@
 /* Enabled if forced with data-theme="dark" */
 [data-theme="dark"] {
     @include pagefind-dark-vars;
-
-    --pico-primary: #21E299; /* Jade 200 */
-    --pico-primary-underline: rgba(33, 226, 153, 0.5);
-    --pico-primary-hover: #00A66E; /* Jade 400 */
+    @include dark-theme-vars;
 
     .dark-mode-toggle {
         .light-icon {

--- a/tests/accessibility.spec.js
+++ b/tests/accessibility.spec.js
@@ -67,13 +67,17 @@ test.describe("site-pages", () => {
   });
 
   // TC-078
+  // Upstream Pagefind issue: the component UI ships keyboard-hint text and kbd
+  // badges with colours that fail WCAG AA contrast. Defaults `--pf-text-muted: #767676`
+  // (4.48:1 on #fff) and `--pf-text-secondary: #666` are at or below threshold,
+  // and Pagefind's selectors use an `:is(*, #\#)`-stacked specificity hack that
+  // resists consumer overrides via the documented CSS variables. Tracking via
+  // upstream issue — re-enable once fixed there.
   test.fixme("search modal should not have accessibility issues", async ({ page }) => {
     await page.goto("/");
     await page.locator("pagefind-modal-trigger button").click();
     await expect(page.locator("dialog.pf-modal[open]")).toBeVisible();
 
-    // Pagefind's component UI ships keyboard-hint text and kbd badges that fail
-    // WCAG AA color contrast (#999/#8d8d8d on #fff/#f8f8f8). Tracked as a follow-up.
     const accessibilityScanResults = await new AxeBuilder({ page })
       .include("dialog.pf-modal")
       .analyze();
@@ -121,16 +125,20 @@ test("should not have any automatically detectable WCAG A or AA violations", asy
 });
 
 // TC-082
-test.fixme("dark mode should not introduce any automatically detectable accessibility issues", async ({ page }) => {
+test("dark mode should not introduce any automatically detectable accessibility issues", async ({ page }) => {
+  // Suppress CSS transitions so axe doesn't capture mid-transition colour values
+  // (Firefox in particular reads link colours mid-tween, producing false violations).
+  await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/");
+
+  // On mobile viewports the dark-mode toggle is inside .nav-utilities, hidden behind
+  // the burger menu, so open it first.
+  const burger = page.locator("label[for*='burger-menu']");
+  if (await burger.isVisible()) await burger.click();
 
   await page.getByRole("button", { name: "Dark/Light Mode" }).click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
-  // In dark mode, the Pico CSS Jade theme's primary link/button colour (#008f5e) has
-  // insufficient contrast ratio of 4.35:1 against the dark background (#13171f), falling
-  // short of the WCAG 2 AA requirement of 4.5:1. This affects nav links, footer links,
-  // and CTA buttons. This is a genuine colour contrast issue in the dark mode theme.
   const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 
   expect(accessibilityScanResults.violations).toEqual([]);

--- a/tests/functional.spec.js
+++ b/tests/functional.spec.js
@@ -2,30 +2,6 @@
 import { test, expect } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
-// TC-001, TC-005, TC-006 (partial), TC-008, TC-014 (partial) — recorder smoke test
-// ---------------------------------------------------------------------------
-
-test("basic", async ({ page }) => {
-  await page.goto("/");
-  await expect(page).toHaveTitle(/Kit France/);
-  await page.goto("/");
-  await page.getByRole("button", { name: "About" }).click();
-  await expect(page.getByRole("heading", { name: "About" })).toBeVisible();
-  await page.getByRole("link", { name: "CF" }).click();
-  await page.getByRole("button", { name: "Product" }).click();
-  await expect(page.getByRole("article").filter({ hasText: "Business outcomes" })).toBeVisible();
-  await page.getByRole("link", { name: "Side Projects", exact: true }).click();
-  await expect(page.getByText("Jamstack kits-dna My personal")).toBeVisible();
-  await page.getByRole("link", { name: "Blog", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Blog" })).toBeVisible();
-  await page.locator("pagefind-modal-trigger button").click();
-  await expect(page.locator("dialog.pf-modal[open]")).toBeVisible();
-  await page.keyboard.press("Escape");
-  await page.getByRole("link", { name: "Home" }).click();
-  await expect(page.getByRole("button", { name: "Dark/Light Mode" })).toBeVisible();
-});
-
-// ---------------------------------------------------------------------------
 // TC-002, TC-004: Page Load and Routing
 // ---------------------------------------------------------------------------
 
@@ -43,6 +19,8 @@ test.describe("Page Load and Routing", () => {
       "/contact",
       "/accessibility",
       "/privacy",
+      "/feed.xml",
+      "/sitemap.xml",
     ];
 
     for (const url of urls) {
@@ -171,7 +149,8 @@ test.describe("Dark / Light Mode Toggle", () => {
 
     await page.getByRole("button", { name: "Dark/Light Mode" }).click();
 
-    await expect(page.locator("html")).toHaveAttribute("data-theme", initialTheme ?? /dark|light/);
+    if (initialTheme === null) throw new Error("expected initial data-theme attribute to be set");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", initialTheme);
   });
 
   // TC-016
@@ -182,7 +161,8 @@ test.describe("Dark / Light Mode Toggle", () => {
 
     await page.goto("/about");
 
-    await expect(page.locator("html")).toHaveAttribute("data-theme", themeSwitchedTo ?? /dark|light/);
+    if (themeSwitchedTo === null) throw new Error("expected data-theme attribute to be set after toggle");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", themeSwitchedTo);
 
     const storedTheme = await page.evaluate(() => localStorage.getItem("theme"));
     expect(storedTheme).toBe(themeSwitchedTo);
@@ -312,9 +292,10 @@ test.describe("Blog Page and Blog Posts", () => {
 
     const currentHeading = await page.getByRole("heading", { level: 1 }).innerText();
     const nextHref = await nextLink.getAttribute("href");
+    if (nextHref === null) throw new Error("expected next-post link to have an href");
     await nextLink.click();
 
-    await expect(page).toHaveURL(nextHref ?? /\/blog\//);
+    await expect(page).toHaveURL(nextHref);
 
     const newHeading = await page.getByRole("heading", { level: 1 }).innerText();
     expect(newHeading).not.toBe(currentHeading);
@@ -642,11 +623,19 @@ test.describe("SEO and Meta Tags", () => {
 // TC-065: External Links
 // ---------------------------------------------------------------------------
 
-test("external links", async ({ page }) => {
+test("all external homepage links have target=_blank and rel containing noopener+noreferrer", async ({ page }) => {
   await page.goto("/");
-  const externalLinks = page.locator("a[target=\"_blank\"], a[href^=\"http\"]");
-  if (await externalLinks.count() > 0) {
-    await expect(externalLinks.first()).toHaveAttribute("target", "_blank");
+  const externalLinks = page.locator("a[href^=\"http\"]:not([href*=\"kitfrance.com\"])");
+  const count = await externalLinks.count();
+  expect(count).toBeGreaterThan(0);
+  for (let i = 0; i < count; i++) {
+    const link = externalLinks.nth(i);
+    const href = await link.getAttribute("href");
+    await expect(link, `external link #${i} (${href}) missing target=_blank`).toHaveAttribute("target", "_blank");
+    const rel = await link.getAttribute("rel");
+    expect(rel, `external link #${i} (${href}) missing rel attribute`).not.toBeNull();
+    expect(rel, `external link #${i} (${href}) rel missing noopener`).toMatch(/noopener/);
+    expect(rel, `external link #${i} (${href}) rel missing noreferrer`).toMatch(/noreferrer/);
   }
 });
 

--- a/tests/mobile.spec.js
+++ b/tests/mobile.spec.js
@@ -106,15 +106,16 @@ test.describe("Mobile Browser Tests", () => {
   // TC-012: Mobile nav links navigate to correct pages
   test("mobile nav links navigate to correct pages", async ({ page }) => {
     const menuButton = page.locator("label[for*='burger-menu']");
+    const nav = page.getByRole("navigation");
 
     await menuButton.click();
-    await page.getByRole("link", { name: "About", exact: true }).click();
+    await nav.getByRole("link", { name: "About", exact: true }).click();
     await expect(page).toHaveURL(/\/about/);
 
     await page.goto("/");
     await menuButton.click();
-    await page.getByRole("link", { name: "Contact", exact: true }).click();
-    await expect(page).toHaveURL(/\/contact/);
+    await nav.getByRole("link", { name: "Résumé", exact: true }).click();
+    await expect(page).toHaveURL(/\/resume/);
   });
 
   // TC-013: Mobile landscape orientation does not break layout


### PR DESCRIPTION
## Summary

Addresses [#303](https://github.com/makendon/kits-dna/issues/303) — clean up pre-existing test issues identified during the `functional.spec.js` consolidation review, plus an inline follow-up to actually fix the dark-mode contrast `test.fixme` that surfaced while reviewing the accessibility suite.

### Part A — test cleanup (commit `fdb06b3`)

- **Remove redundant `test("basic", ...)`** in `functional.spec.js` — every step is already covered by TC-005, TC-006, TC-008, TC-014, TC-088.
- **Strengthen TC-065** to assert `target=_blank` and `rel` contains both `noopener` and `noreferrer` on every external homepage link (was a single-link check that skipped if none found).
- **Fix nullable fallbacks** in TC-015, TC-016, TC-028: replace `?? /regex/` with explicit `if (x === null) throw …` so missing attributes fail loudly rather than silently matching the fallback regex.
- **TC-002**: add `/feed.xml` and `/sitemap.xml` to the URL list and flip `test-plan.md` status from `Not covered` → `Covered`.
- **Fix mobile TC-012**: scope the link lookup to the navigation landmark and swap the removed `Contact` link for `Résumé` — was passing by accident via the footer link.

### Part B — TC-082 dark-mode contrast (commit `abdf169`)

The Pico CSS Jade dark scheme renders nav-link / outline-button text at the light-scheme value (`#007a50`) on `#13171f` — 4.35:1, below WCAG AA's 4.5:1. Override `--pico-primary`, `--pico-primary-underline`, and `--pico-primary-hover` to jade-200 (`#21E299`) in `_dark-mode.scss`, lifting contrast to ~11.3:1.

The test itself was made portable so it can run unfixmed across every project:

- Emulate `prefers-reduced-motion: reduce` so axe doesn't sample link colours mid-tween (Firefox-specific flake).
- Open the burger menu on mobile viewports so the dark-mode toggle inside `.nav-utilities` is reachable.

### Out of scope — TC-078 (Pagefind modal contrast)

Investigated but stays `test.fixme`. The contrast violations sit in upstream Pagefind component CSS, and the documented `--pf-*` variables can't override the rendered colour (something opaque in the component prevents reaching contrast even when CSS variables compute correctly). Comment in `accessibility.spec.js` updated to record the findings; will track upstream.

## Test plan

- [x] `npx playwright test --project=chromium` — full functional suite passes
- [x] `npx playwright test tests/accessibility.spec.js` — all 60 (5 projects × 12 tests) accessibility tests pass, 5 skipped (TC-078 fixme on each project)
- [x] `npx playwright test --project="Mobile Chrome" tests/mobile.spec.js -g "mobile nav links"` — TC-012 passes with the new Résumé assertion
- [x] Visual check: in dark mode, nav links / outline buttons render bright jade-200 against the dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)