### PR TITLE
fix: skip view transitions when reduced motion is preferred

### DIFF
--- a/src/_sass/_custom.scss
+++ b/src/_sass/_custom.scss
@@ -384,6 +384,10 @@ form[name="contact"] {
 }
 
 // CSS transitions
-@view-transition {
-  navigation: auto;
+// Skipped for anyone who prefers reduced motion: view transitions animate the
+// whole page and can trigger vestibular discomfort.
+@media (prefers-reduced-motion: no-preference) {
+  @view-transition {
+    navigation: auto;
+  }
 }

--- a/tests/accessibility.spec.js
+++ b/tests/accessibility.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures.js";
 import AxeBuilder from "@axe-core/playwright";
 
 test.describe("site-pages", () => {

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -1,0 +1,21 @@
+import { test as base, expect } from "@playwright/test";
+
+// Chromium 149+ suspends rendering while a cross-document view transition is
+// pending, and under automation that transition never completes, so the page
+// stops producing animation frames entirely. Playwright's actionability check
+// waits for an element's box to stay stable across two frames, so every click
+// after a navigation hangs until it times out.
+//
+// Emulating reduced motion means the site's `@view-transition` rule never
+// applies, since it is guarded by `prefers-reduced-motion: no-preference`.
+// Setting `reducedMotion` in playwright.config.js does not work: as of 1.61 it
+// is resolved into the project options but never applied to the browser
+// context, so it has to be set on the page.
+const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await use(page);
+  },
+});
+
+export { test, expect };

--- a/tests/functional.spec.js
+++ b/tests/functional.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures.js";
 
 // ---------------------------------------------------------------------------
 // TC-002, TC-004: Page Load and Routing

--- a/tests/mobile.spec.js
+++ b/tests/mobile.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures.js";
 
 test.describe("Mobile Browser Tests", () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## What

Guards the site's cross-document view transition behind `prefers-reduced-motion: no-preference`, and has the Playwright suite emulate reduced motion via a shared fixture.

Unblocks #332 (the `npm-deps` group bump), which currently fails four Playwright tests.

## Why

#332 bumps `@playwright/test` 1.60 → 1.61, which ships **Chromium 149** (up from 148). The site opts into cross-document view transitions unconditionally:

```scss
@view-transition { navigation: auto; }
```

Chromium 149+ suspends rendering while such a transition is pending, and under browser automation the transition never completes — so the page produces **no animation frames at all**. Playwright's actionability check waits for an element's bounding box to stay stable across two consecutive frames, so every click *after* a navigation hangs until it times out:

```
Error: locator.click: Test timeout of 30000ms exceeded.
  - locator resolved to <a href="/product/">Product</a>
  - attempting click action
    - waiting for element to be visible, enabled and stable
```

Four tests fail, all on the Chromium projects (`chromium`, `Mobile Chrome`). Firefox and WebKit are unaffected.

**This was never user facing.** A normally launched Chrome completes the transition and renders fine — the freeze only occurs when the browser is driven by Playwright. Confirmed by attaching to a normal Chrome 150 over CDP (renders fine) and by reproducing the freeze with a bare three-line HTML file containing nothing but `@view-transition`, which rules out anything site-specific.

## How

- **`src/_sass/_custom.scss`** — wrap the rule in `@media (prefers-reduced-motion: no-preference)`. Worth doing on its own merits: view transitions animate the whole page and can trigger vestibular discomfort, so honouring the preference is an accessibility improvement independent of the test failures.
- **`tests/fixtures.js`** (new) — overrides the `page` fixture to call `page.emulateMedia({ reducedMotion: "reduce" })`, so the guarded rule never applies while tests run. Fixture setup runs before any `beforeEach`, so the emulation is in place before the first `page.goto()`.
- **three spec files** — import `test`/`expect` from `./fixtures.js` instead of `@playwright/test`. One-line change each; no test logic touched.

Real users still get the transition; only reduced-motion users and automated browsers skip it.

### Note on `playwright.config.js`

The obvious one-liner — `reducedMotion: "reduce"` in `use` — **silently does nothing in Playwright 1.61**. It is resolved into `project.use`, but never applied to the browser context (`matchMedia("(prefers-reduced-motion: reduce)")` still reports `false` in the page). Hence the fixture. The config is deliberately left untouched rather than carrying a dead setting that looks load-bearing.

## Verification

Full suite, all five browser projects:

| Playwright | Context | Result |
| --- | --- | --- |
| 1.60 | this branch (matches current `main`) | 220 passed, 5 skipped, 0 failed |
| 1.61 | #332's branch with this fix applied | 220 passed, 5 skipped, 0 failed |

Previously on #332: 216 passed, **4 failed**. ESLint clean on both.

This branch does **not** bump Playwright — that stays in #332. Once this merges, rebasing #332 picks the fix up and it should go green.

> [!NOTE]
> CI on this branch runs Playwright 1.60, so it will pass without exercising the 1.61 path. The 1.61 result above was verified locally (macOS); CI runs Ubuntu. The failure reproduced identically in both, but the 1.61 side gets its real CI proof when #332 rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)